### PR TITLE
Update I2C.py

### DIFF
--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -51,7 +51,8 @@ def get_default_bus():
             return 1
     elif plat == Platform.BEAGLEBONE_BLACK:
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
-        return 1
+        # Beaglebone Black revc debian9 defaults to 2 (P9_19 and P9_20).
+        return 2
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 


### PR DESCRIPTION
Support for newer beaglebone black devices that use I2C bus 2 mapped to p19 and 20.